### PR TITLE
관리자 화면 상태 컬럼 셀별 버튼 및 모달창 추가

### DIFF
--- a/src/components/modules/Table/index.jsx
+++ b/src/components/modules/Table/index.jsx
@@ -46,7 +46,7 @@ const Table = ({ data }) => {
         {data.map((row, rowIndex) => (
           <TableRow key={rowIndex}>
             {headers.map((header, index) => (
-              <TableCell key={index}>{typeof row[header] !== 'object' ? row[header] : ''}</TableCell>
+              <TableCell key={index}>{row[header]}</TableCell>
             ))}
           </TableRow>
         ))}

--- a/src/components/templates/Admin/index.jsx
+++ b/src/components/templates/Admin/index.jsx
@@ -23,7 +23,11 @@ export default function Confirm() {
   }, []);
 
   const mapDataToColumns = (data) => {
-    return data.map((item) => ({
+    if (!data || !data.item) {
+      return [];
+    }
+  
+    return data.item.map((item) => ({
       시작일자: item.startDate,
       종료일자: item.endDate,
       신청일: item.createdDate,
@@ -32,6 +36,7 @@ export default function Confirm() {
       상태: <Button>{item.status.description}</Button>,
     }));
   };
+   
 
   return (
     <div>

--- a/src/components/templates/Admin/index.jsx
+++ b/src/components/templates/Admin/index.jsx
@@ -1,13 +1,18 @@
-// TableWithApi.js
-
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import Table from '@modules/Table';
 import Button from '@atoms/Button';
+import Modal from '@modules/Modal';
 import { SERVER_HOST } from '@config/config';
+import { useModalContext } from '@modules/Modal/ModalContext';
+import Input from '@atoms/Input';
+import { FlexContainer } from '@atoms/Flex';
+import SelectList from '@atoms/SelectList';
 
 export default function Confirm() {
+  const { openModal, closeModal } = useModalContext();
   const [reservationData, setReservationData] = useState([]);
+  const [selectedReservation, setSelectedReservation] = useState(null);
 
   const fetchData = async () => {
     try {
@@ -26,21 +31,46 @@ export default function Confirm() {
     if (!data || !data.item) {
       return [];
     }
-  
+
     return data.item.map((item) => ({
       시작일자: item.startDate,
       종료일자: item.endDate,
       신청일: item.createdDate,
       예약자명: item.name,
       전화번호: item.phoneNumber,
-      상태: <Button>{item.status.description}</Button>,
+      상태: (
+        <Button onClick={() => handleReservationClick(item)}>
+          {item.status.description}
+        </Button>
+      ),
     }));
   };
-   
+
+  const handleReservationClick = (reservation) => {
+    setSelectedReservation(reservation);
+    openModal('statusModal');
+  };
+
+  const closeModalHandler = () => {
+    setSelectedReservation(null);
+    closeModal('statusModal');
+  };
 
   return (
-    <div>
+    <FlexContainer $justifyContent="space-between" $alignItems="center">
       <Table data={mapDataToColumns(reservationData)} />
-    </div>
+      {selectedReservation && (
+        <Modal title="상태 확인" modalId="statusModal" hasButton={false}>
+          <FlexContainer $column $gap="16px">
+            <Input label="예약자명" readOnly value={selectedReservation.name} />
+            <Input label="전화번호" readOnly value={selectedReservation.phoneNumber} />
+            <SelectList label="상태" value={selectedReservation.status.description} />
+          </FlexContainer>
+          <FlexContainer $justifyContent="flex-end">
+            <Button onClick={closeModalHandler}>확인</Button>
+          </FlexContainer>
+        </Modal>
+      )}
+    </FlexContainer>
   );
 }

--- a/src/components/templates/Admin/index.jsx
+++ b/src/components/templates/Admin/index.jsx
@@ -29,7 +29,7 @@ export default function Confirm() {
       신청일: item.createdDate,
       예약자명: item.name,
       전화번호: item.phoneNumber,
-      상태: item.status.description,
+      상태: <Button>{item.status.description}</Button>,
     }));
   };
 

--- a/src/components/templates/Admin/index.jsx
+++ b/src/components/templates/Admin/index.jsx
@@ -35,7 +35,6 @@ export default function Confirm() {
 
   return (
     <div>
-      <Button onClick={fetchData}>새로고침</Button>
       <Table data={mapDataToColumns(reservationData)} />
     </div>
   );

--- a/src/components/templates/Admin/index.jsx
+++ b/src/components/templates/Admin/index.jsx
@@ -3,17 +3,32 @@ import axios from 'axios';
 import Table from '@modules/Table';
 import Button from '@atoms/Button';
 import Modal from '@modules/Modal';
+import Input from '@atoms/Input';
+import SelectList from '@atoms/SelectList';
+import { FlexContainer } from '@atoms/Flex';
 import { SERVER_HOST } from '@config/config';
 import { useModalContext } from '@modules/Modal/ModalContext';
-import Input from '@atoms/Input';
-import { FlexContainer } from '@atoms/Flex';
-import SelectList from '@atoms/SelectList';
 
-export default function Confirm() {
+const Confirm = () => {
   const { openModal, closeModal } = useModalContext();
   const [reservationData, setReservationData] = useState([]);
   const [selectedReservation, setSelectedReservation] = useState(null);
+  const [selectedStatus, setSelectedStatus] = useState(null);
+  const [originalStatus, setOriginalStatus] = useState(null);
 
+  const statusOptions = [
+    { value: 1, label: "승인 대기" },
+    { value: 2, label: "승인" },
+    { value: 3, label: "취소" },
+    { value: 4, label: "반려" },
+    { value: 5, label: "이용완료" },
+  ];
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  // 데이터를 불러오는 함수
   const fetchData = async () => {
     try {
       const response = await axios.get(`http://${SERVER_HOST}/reservations`);
@@ -23,10 +38,56 @@ export default function Confirm() {
     }
   };
 
-  useEffect(() => {
-    fetchData();
-  }, []);
+  // 예약 상태를 업데이트하는 함수
+  const handleConfirmButtonClick = async (newStatus) => {
+    try {
+      // API 호출을 통해 상태 업데이트
+      await axios.post(`http://${SERVER_HOST}/reservations/${selectedReservation.id}`, {
+        status: newStatus,
+      });
 
+      // 데이터 다시 불러오기
+      fetchData();
+    } catch (error) {
+      console.error('Error updating status:', error);
+    } finally {
+      // 팝업 닫기
+      closeModal('statusModal');
+    }
+  };
+
+  // 예약 상태 변경 확인 여부를 묻는 함수
+  const askConfirmation = (selectedOption) => {
+    const newStatus = selectedOption.value;
+    const isStatusChanged = newStatus !== originalStatus;
+
+    if (isStatusChanged) {
+      const isConfirmed = window.confirm(
+        `"${selectedOption.label}" 상태로 변경하시겠습니까?`
+      );
+
+      if (isConfirmed) {
+        // 변경이 확인되면 업데이트 수행
+        handleConfirmButtonClick(newStatus);
+      }
+    }
+  };
+
+  // 예약 상태 변경 시 호출되는 콜백 함수
+  const handleStatusChange = (selectedOption) => {
+    setSelectedStatus(selectedOption.value);
+    askConfirmation(selectedOption);
+  };
+
+  // 예약 상태 클릭 시 호출되는 함수
+  const handleReservationClick = (reservation) => {
+    setSelectedReservation(reservation);
+    setSelectedStatus(reservation.status.status);
+    setOriginalStatus(reservation.status.status);
+    openModal('statusModal');
+  };
+
+  // 예약 데이터를 테이블 형태로 매핑하는 함수
   const mapDataToColumns = (data) => {
     if (!data || !data.item) {
       return [];
@@ -46,31 +107,28 @@ export default function Confirm() {
     }));
   };
 
-  const handleReservationClick = (reservation) => {
-    setSelectedReservation(reservation);
-    openModal('statusModal');
-  };
-
-  const closeModalHandler = () => {
-    setSelectedReservation(null);
-    closeModal('statusModal');
-  };
-
   return (
     <FlexContainer $justifyContent="space-between" $alignItems="center">
       <Table data={mapDataToColumns(reservationData)} />
       {selectedReservation && (
-        <Modal title="상태 확인" modalId="statusModal" hasButton={false}>
+        <Modal title="상태 확인" modalId="statusModal">
           <FlexContainer $column $gap="16px">
+            <Input label="시작일자" readOnly value={selectedReservation.startDate} />
+            <Input label="종료일자" readOnly value={selectedReservation.endDate} />
+            <Input label="신청일" readOnly value={selectedReservation.createdDate} />
             <Input label="예약자명" readOnly value={selectedReservation.name} />
             <Input label="전화번호" readOnly value={selectedReservation.phoneNumber} />
-            <SelectList label="상태" value={selectedReservation.status.description} />
-          </FlexContainer>
-          <FlexContainer $justifyContent="flex-end">
-            <Button onClick={closeModalHandler}>확인</Button>
+            <SelectList
+              label="상태"
+              value={statusOptions.find(option => option.value === selectedStatus)}
+              options={statusOptions}
+              onChange={handleStatusChange}
+            />
           </FlexContainer>
         </Modal>
       )}
     </FlexContainer>
   );
-}
+};
+
+export default Confirm;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,1 +1,1 @@
-export const SERVER_HOST = 'http://3.36.35.77:8080';
+export const SERVER_HOST = '3.36.35.77:8080';

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,1 +1,1 @@
-export const SERVER_HOST = 'localhost:8080';
+export const SERVER_HOST = 'http://3.36.35.77:8080';


### PR DESCRIPTION
아래 이미지와 같이 **상태 컬럼 각 셀마다 버튼으로 변경**했고, **각 버튼 눌렀을 때 모달창 뜨도록** 개발하였습니다.

![image](https://github.com/Disposable-Development-Team/yeah-yak-frontend/assets/83532056/685d4325-d3df-497b-90f0-f7f8b07691bd)

이후 
1. 모달창에 필요한 내용 정의 및 드롭다운 수정
2. 실제 POST 동작하도록 연동
3. 상태 변경하고 확인 버튼 클릭시 재확인 문구 뜨도록 설정

진행하면 될 것 같습니다.